### PR TITLE
feat(ristretto): add base url helper

### DIFF
--- a/.changeset/five-games-give.md
+++ b/.changeset/five-games-give.md
@@ -1,0 +1,5 @@
+---
+'@slango/ristretto': patch
+---
+
+withBaseUrl helper

--- a/packages/ristretto/src/abortable/index.ts
+++ b/packages/ristretto/src/abortable/index.ts
@@ -5,6 +5,8 @@ import { Request as BaseRequest, RequestOptionsWithoutUrl, RequestURL } from '..
 export type { AbortablePromise } from '../utils/abortableRequest.js';
 export { withBearerToken } from '../utils/auth.js';
 export type { BaseURL } from '../utils/baseUrl.js';
+export { withBaseUrl } from '../utils/baseUrl.js';
+
 export { withFormDataBody, withJsonBody } from '../utils/body.js';
 export { HttpError } from '../utils/HttpError.js';
 export { withQueryParams } from '../utils/queryParams.js';

--- a/packages/ristretto/src/index.ts
+++ b/packages/ristretto/src/index.ts
@@ -8,6 +8,7 @@ import {
 
 export { withBearerToken } from './utils/auth.js';
 export type { BaseURL } from './utils/baseUrl.js';
+export { withBaseUrl } from './utils/baseUrl.js';
 export { withFormDataBody, withJsonBody } from './utils/body.js';
 export { HttpError } from './utils/HttpError.js';
 export { withQueryParams } from './utils/queryParams.js';

--- a/packages/ristretto/src/utils/baseUrl.ts
+++ b/packages/ristretto/src/utils/baseUrl.ts
@@ -13,4 +13,5 @@ export const getDefaultBaseUrl = (): string => {
   return baseUrl;
 };
 
-// TODO: We neeed a withBaseUrl helper
+// Helper to preset a base URL on requests.
+export { withBaseUrl } from './withBaseUrl.js';

--- a/packages/ristretto/src/utils/withBaseUrl.spec.ts
+++ b/packages/ristretto/src/utils/withBaseUrl.spec.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { HttpMethod } from './httpMethod.js';
+import { request, RequestOptionsWithoutUrl } from './request.js';
+import { withBaseUrl } from './withBaseUrl.js';
+
+describe('withBaseUrl', () => {
+  const mockFetch = vi.fn();
+  globalThis.fetch = mockFetch;
+
+  afterEach(() => {
+    mockFetch.mockClear();
+  });
+
+  const mockedResponseFactory = <T extends Record<string, unknown>>(data: T) => ({
+    body: JSON.stringify(data),
+    json: () => Promise.resolve(data),
+    ok: true,
+  });
+
+  const baseRequest = (options?: RequestOptionsWithoutUrl) =>
+    request<{ message: string }>(HttpMethod.GET, { ...options, url: '/data' });
+
+  it('should apply default base URL when none provided in options', async () => {
+    const req = withBaseUrl('https://api.example.com')(baseRequest);
+    const mockResponseData = { message: 'Success' };
+    mockFetch.mockResolvedValueOnce(mockedResponseFactory(mockResponseData));
+
+    const result = await req();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/data', {
+      headers: undefined,
+      method: HttpMethod.GET,
+    });
+    expect(result).toEqual(mockResponseData);
+  });
+
+  it('should allow overriding base URL in options', async () => {
+    const req = withBaseUrl('https://api.example.com')(baseRequest);
+    const mockResponseData = { message: 'Override' };
+    mockFetch.mockResolvedValueOnce(mockedResponseFactory(mockResponseData));
+
+    const result = await req({ baseUrl: 'https://override.example.com' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledWith('https://override.example.com/data', {
+      headers: undefined,
+      method: HttpMethod.GET,
+    });
+    expect(result).toEqual(mockResponseData);
+  });
+});

--- a/packages/ristretto/src/utils/withBaseUrl.ts
+++ b/packages/ristretto/src/utils/withBaseUrl.ts
@@ -1,0 +1,12 @@
+import type { BaseURL } from './baseUrl.js';
+
+import { AbortablePromise } from './abortableRequest.js';
+import { Request, RequestOptionsWithoutUrl } from './request.js';
+
+export const withBaseUrl =
+  (baseUrl: BaseURL) =>
+  <Response, PromiseType extends AbortablePromise<Response> | Promise<Response>>(
+    req: Request<Response, PromiseType>,
+  ): Request<Response, PromiseType> =>
+  (options: RequestOptionsWithoutUrl = {}) =>
+    req({ baseUrl, ...options });


### PR DESCRIPTION
## Summary
- add `withBaseUrl` to preset a base URL for requests
- re-export helper through `baseUrl` and `index`
- test default base URL usage and override capability

## Testing
- `pnpm --filter @slango/ristretto test`

------
https://chatgpt.com/codex/tasks/task_b_689664854ff8832389193eaad7af6683