### PR TITLE
fix timestamp middleware update field

### DIFF
--- a/.changeset/large-yaks-beam.md
+++ b/.changeset/large-yaks-beam.md
@@ -1,0 +1,5 @@
+---
+'@slango/mangusta': patch
+---
+
+Fixed issue with timestamps middleware that affected update field (wrong name of field and clash with creation)

--- a/packages/mangusta/src/middleware/timestamps.spec.ts
+++ b/packages/mangusta/src/middleware/timestamps.spec.ts
@@ -1,0 +1,81 @@
+import { setupMongoTestEnvironment } from '@slango.configs/vitest/helpers/mongooseTestEnvironment';
+import mongoose, { Document, model, Schema } from 'mongoose';
+import { setTimeout as delay } from 'node:timers/promises';
+import { describe, expect, it } from 'vitest';
+
+import timestampsMiddleware, { TimestampsMiddlewareOptions, WithTimestamps } from './timestamps.js';
+
+setupMongoTestEnvironment();
+
+type TestDoc = Document & WithTimestamps & { name: string };
+
+const createTestModel = (options?: TimestampsMiddlewareOptions) => {
+  const modelName = 'TestDoc';
+
+  if (mongoose.models[modelName]) {
+    delete mongoose.models[modelName];
+  }
+
+  const TestSchema = new Schema<TestDoc>({
+    name: String,
+  });
+
+  if (options) {
+    TestSchema.plugin(timestampsMiddleware, options);
+  } else {
+    TestSchema.plugin(timestampsMiddleware);
+  }
+
+  return model<TestDoc>(modelName, TestSchema);
+};
+
+describe('timestampsMiddleware', () => {
+  it('should store creation and update timestamps correctly on save', async () => {
+    const TestModel = createTestModel();
+    const doc = new TestModel({ name: 'initial' });
+
+    await expect(doc.save()).resolves.not.toThrow();
+
+    const savedDoc = await TestModel.findById(doc._id);
+    expect(savedDoc).not.toBeNull();
+    if (!savedDoc) return;
+    expect(savedDoc.created).toBeInstanceOf(Date);
+    expect(savedDoc.updated).toBeNull();
+
+    await delay(10);
+    savedDoc.name = 'changed';
+    await expect(savedDoc.save()).resolves.not.toThrow();
+
+    const updatedDoc = await TestModel.findById(doc._id);
+    expect(updatedDoc).not.toBeNull();
+    if (!updatedDoc) return;
+    expect(updatedDoc.created).toEqual(savedDoc.created);
+    expect(updatedDoc.updated).toBeInstanceOf(Date);
+    if (!updatedDoc.created || !updatedDoc.updated) return;
+    expect(updatedDoc.updated.getTime()).toBeGreaterThan(updatedDoc.created.getTime());
+  });
+
+  it('should update timestamp when using updateOne operations', async () => {
+    const TestModel = createTestModel();
+    const doc = new TestModel({ name: 'initial' });
+    await doc.save();
+
+    await delay(10);
+    await TestModel.updateOne({ _id: doc._id }, { name: 'updated' });
+
+    const updatedDoc = await TestModel.findById(doc._id);
+    expect(updatedDoc).not.toBeNull();
+    if (!updatedDoc) return;
+    expect(updatedDoc.updated).toBeInstanceOf(Date);
+    if (!updatedDoc.created || !updatedDoc.updated) return;
+    expect(updatedDoc.updated.getTime()).toBeGreaterThan(updatedDoc.created.getTime());
+  });
+
+  it('should add an index on the update field when indexUpdate is true', () => {
+    const TestModel = createTestModel({ indexUpdate: true });
+    const indexes = TestModel.schema.indexes();
+
+    const index = indexes.find(([fields]) => fields.updated === 1);
+    expect(index).toBeDefined();
+  });
+});

--- a/packages/mangusta/src/middleware/timestamps.ts
+++ b/packages/mangusta/src/middleware/timestamps.ts
@@ -49,7 +49,7 @@ const timestampsMiddleware: PluginFunction<TimestampsMiddlewareOptions> = <
   if (update) {
     schema.add(
       new Schema<WithUpdated<Updated>>({
-        [creationField]: Date,
+        [updateField]: Date,
       }),
     );
   }


### PR DESCRIPTION
## Summary
- fix timestamp middleware to register update timestamp using `updateField`
- add comprehensive tests for timestamp middleware

## Testing
- `pnpm --filter @slango/mangusta lint`
- `pnpm --filter @slango/mangusta test`


------
https://chatgpt.com/codex/tasks/task_b_68966496bffc832383d5078a013e3292