### PR TITLE
test: add password and timestamps middleware specs

### DIFF
--- a/packages/mangusta/src/middleware/password.spec.ts
+++ b/packages/mangusta/src/middleware/password.spec.ts
@@ -1,0 +1,88 @@
+import { setupMongoTestEnvironment } from '@slango.configs/vitest/helpers/mongooseTestEnvironment';
+import mongoose, { Document, model, Schema } from 'mongoose';
+import { describe, expect, it } from 'vitest';
+
+import type { PluginFunction } from '../types.js';
+import passwordMiddleware, {
+  PasswordMiddlewareOptions,
+  WithPassword,
+} from './password.js';
+
+setupMongoTestEnvironment();
+
+type TestDoc<
+  Field extends string = 'password',
+  ComparisonFunction extends string = 'comparePassword',
+> = Document & WithPassword<Field, ComparisonFunction>;
+
+const createTestModel = <
+  Field extends string = 'password',
+  ComparisonFunction extends string = 'comparePassword',
+>(options?: PasswordMiddlewareOptions<Field, ComparisonFunction>) => {
+  const modelName = 'TestDoc';
+
+  if (mongoose.models[modelName]) {
+    delete mongoose.models[modelName];
+  }
+
+  const TestSchema = new Schema<TestDoc<Field, ComparisonFunction>>({});
+  if (options) {
+    TestSchema.plugin(
+      passwordMiddleware as PluginFunction<
+        PasswordMiddlewareOptions<Field, ComparisonFunction>
+      >,
+      options,
+    );
+  } else {
+    TestSchema.plugin(passwordMiddleware);
+  }
+
+  return model<TestDoc<Field, ComparisonFunction>>(modelName, TestSchema);
+};
+
+describe('passwordMiddleware', () => {
+  it('should hash password and provide comparison method', async () => {
+    const TestModel = createTestModel();
+    const plain = 'Valid@123';
+    const doc = new TestModel({ password: plain });
+
+    await expect(doc.save()).resolves.not.toThrow();
+    const saved = await TestModel.findById(doc._id);
+
+    expect(saved).toBeDefined();
+    expect(saved!.password).not.toBe(plain);
+    await expect(saved!.comparePassword(plain)).resolves.toBe(true);
+    await expect(saved!.comparePassword('Wrong@123')).resolves.toBe(false);
+  });
+
+  it('should reject invalid passwords', async () => {
+    const TestModel = createTestModel();
+    const doc = new TestModel({ password: 'invalid' });
+
+    await expect(doc.save()).rejects.toThrowError(mongoose.Error.ValidationError);
+  });
+
+  it('should allow configuring field and comparison function names', async () => {
+    const TestModel = createTestModel<'pass', 'checkPassword'>({
+      field: 'pass',
+      comparisonFunction: 'checkPassword',
+    });
+    const doc = new TestModel({ pass: 'Valid@123' });
+
+    await expect(doc.save()).resolves.not.toThrow();
+    const saved = (await TestModel.findById(
+      doc._id,
+    )) as TestDoc<'pass', 'checkPassword'> | null;
+
+    expect(saved).toBeDefined();
+    await expect(saved!.checkPassword('Valid@123')).resolves.toBe(true);
+  });
+
+  it('should allow optional password field when required is false', async () => {
+    const TestModel = createTestModel({ required: false });
+    const doc = new TestModel({});
+
+    await expect(doc.save()).resolves.not.toThrow();
+  });
+});
+

--- a/packages/mangusta/src/middleware/password.ts
+++ b/packages/mangusta/src/middleware/password.ts
@@ -14,7 +14,7 @@ export type WithPassword<
 
 export const passwordRegExp = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&*)(\][+=.,_-]).{8,}$/;
 
-interface PasswordMiddlewareOptions<
+export interface PasswordMiddlewareOptions<
   Field extends string = 'password',
   ComparisonFunction extends string = 'comparePassword',
 > {

--- a/packages/mangusta/src/middleware/timestamps.spec.ts
+++ b/packages/mangusta/src/middleware/timestamps.spec.ts
@@ -1,0 +1,85 @@
+import { setupMongoTestEnvironment } from '@slango.configs/vitest/helpers/mongooseTestEnvironment';
+import mongoose, { Document, model, Schema } from 'mongoose';
+import { describe, expect, it } from 'vitest';
+
+import timestampsMiddleware, {
+  TimestampsMiddlewareOptions,
+  WithTimestamps,
+} from './timestamps.js';
+
+setupMongoTestEnvironment();
+
+type TestDoc<
+  Created extends string = 'created',
+  Updated extends string = 'updated',
+> = Document & WithTimestamps<Created, Updated>;
+
+const createTestModel = <
+  Created extends string = 'created',
+  Updated extends string = 'updated',
+>(options?: TimestampsMiddlewareOptions) => {
+  const modelName = 'TestDoc';
+
+  if (mongoose.models[modelName]) {
+    delete mongoose.models[modelName];
+  }
+
+  const TestSchema = new Schema<TestDoc<Created, Updated>>({});
+  if (options) {
+    TestSchema.plugin(timestampsMiddleware, options);
+  } else {
+    TestSchema.plugin(timestampsMiddleware);
+  }
+
+  return model<TestDoc<Created, Updated>>(modelName, TestSchema);
+};
+
+describe('timestampsMiddleware', () => {
+  it('should set creation timestamp and update timestamp on updates', async () => {
+    const TestModel = createTestModel();
+    const doc = new TestModel({});
+
+    await expect(doc.save()).resolves.not.toThrow();
+    const saved = await TestModel.findById(doc._id).lean();
+
+    expect(saved?.created).toBeInstanceOf(Date);
+    expect(saved?.updated).toBeNull();
+
+    await TestModel.updateOne({ _id: doc._id }, { $set: { foo: 'bar' } });
+    const updated = await TestModel.findById(doc._id).lean();
+
+    expect(updated?.updated).toBeInstanceOf(Date);
+    expect(updated!.updated!.getTime()).toBeGreaterThan((updated!.created as Date).getTime());
+  });
+
+  it('should allow custom field names', async () => {
+    const TestModel = createTestModel<'createdAt', 'updatedAt'>({
+      creationField: 'createdAt',
+      updateField: 'updatedAt',
+    });
+    const doc = new TestModel({});
+
+    await expect(doc.save()).resolves.not.toThrow();
+    const saved = await TestModel.findById(doc._id).lean();
+
+    expect(saved?.createdAt).toBeInstanceOf(Date);
+    expect(saved?.updatedAt).toBeNull();
+
+    await TestModel.updateOne({ _id: doc._id }, { $set: { name: 'test' } });
+    const updated = await TestModel.findById(doc._id).lean();
+
+    expect(updated?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('should set update timestamp on creation when updateTimestampOnCreation is true', async () => {
+    const TestModel = createTestModel({ updateTimestampOnCreation: true });
+    const doc = new TestModel({});
+
+    await expect(doc.save()).resolves.not.toThrow();
+    const saved = await TestModel.findById(doc._id).lean();
+
+    expect(saved?.created).toBeInstanceOf(Date);
+    expect(saved?.updated).toBeInstanceOf(Date);
+  });
+});
+

--- a/packages/mangusta/src/middleware/timestamps.ts
+++ b/packages/mangusta/src/middleware/timestamps.ts
@@ -49,7 +49,7 @@ const timestampsMiddleware: PluginFunction<TimestampsMiddlewareOptions> = <
   if (update) {
     schema.add(
       new Schema<WithUpdated<Updated>>({
-        [creationField]: Date,
+        [updateField]: Date,
       }),
     );
   }


### PR DESCRIPTION
## Summary
- add coverage for password middleware including hashing, validation, and custom options
- test timestamps middleware for creation and update behaviors
- export password options and fix timestamps field definition

## Testing
- `pnpm test --filter @slango/mangusta` *(fails: DownloadError: Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.14.tgz")*

------
https://chatgpt.com/codex/tasks/task_b_6896648b45108323aa07f6e52328f6a8