### PR TITLE
feat(eslint): make perfectionist strictness configurable

### DIFF
--- a/.changeset/perfectionist-levels.md
+++ b/.changeset/perfectionist-levels.md
@@ -2,4 +2,4 @@
 '@slango.configs/eslint': minor
 ---
 
-feat: allow configurable perfectionist rule strictness levels.
+feat: allow configurable perfectionist rule strictness levels via options object with validation.

--- a/configs/eslint/README.md
+++ b/configs/eslint/README.md
@@ -42,13 +42,13 @@ Perfectionist sorting rules can be configured with three levels of strictness:
 - `relaxed` – only enforces module sorting (default)
 - `strict` – enforces sorting for modules, enums, object types and objects
 
-To use a custom level, import the corresponding creator and pass the desired level:
+To use a custom level, import the corresponding creator and pass an options object. Passing an unknown option or an invalid level throws an error:
 
 ```js
 // eslint.config.js
 import { createTypescriptConfig } from '@slango.configs/eslint/typescript.js';
 
-export default createTypescriptConfig('strict');
+export default createTypescriptConfig({ perfectionist: 'strict' });
 ```
 
 ## Things to take into account (and possibly review)

--- a/configs/eslint/src/common.js
+++ b/configs/eslint/src/common.js
@@ -46,8 +46,33 @@ export const perfectionistLevels = {
   },
 };
 
-export const commonRules = (perfectionist = 'relaxed') =>
-  perfectionistLevels[perfectionist] ?? perfectionistLevels.relaxed;
+const defaultOptions = { perfectionist: 'relaxed' };
+
+export const normalizeOptions = (options = {}) => {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new Error('options must be an object');
+  }
+
+  const { perfectionist = defaultOptions.perfectionist, ...rest } = options;
+
+  if (!Object.hasOwn(perfectionistLevels, perfectionist)) {
+    throw new Error(
+      `Invalid perfectionist level "${perfectionist}". Expected one of: ${Object.keys(perfectionistLevels).join(', ')}`,
+    );
+  }
+
+  const unknown = Object.keys(rest);
+  if (unknown.length > 0) {
+    throw new Error(`Unknown option(s): ${unknown.join(', ')}`);
+  }
+
+  return { perfectionist };
+};
+
+export const commonRules = (options) => {
+  const { perfectionist } = normalizeOptions(options);
+  return perfectionistLevels[perfectionist];
+};
 
 export const typescriptConfigs = (files) => [
   ...commonConfigs(files),

--- a/configs/eslint/src/presets/javascript-node.js
+++ b/configs/eslint/src/presets/javascript-node.js
@@ -1,36 +1,42 @@
 import globals from 'globals';
 
-import { commonConfigs, commonRules, globs, ignorePatterns } from '../common.js';
+import { commonConfigs, commonRules, globs, ignorePatterns, normalizeOptions } from '../common.js';
 
-export const baseJavascriptConfig = (perfectionist = 'relaxed') => ({
-  files: [globs.javascript],
-  languageOptions: {
-    globals: {
-      ...globals.node,
+export const baseJavascriptConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  return {
+    files: [globs.javascript],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      parserOptions: {
+        ecmaVersion: 'latest',
+      },
     },
-    parserOptions: {
-      ecmaVersion: 'latest',
+    name: '@slango.configs/eslint/javascript-node',
+    rules: {
+      'import-x/first': 'error',
+      'import-x/no-anonymous-default-export': 'error',
+      ...commonRules(opts),
     },
-  },
-  name: '@slango.configs/eslint/javascript-node',
-  rules: {
-    'import-x/first': 'error',
-    'import-x/no-anonymous-default-export': 'error',
-    ...commonRules(perfectionist),
-  },
-  settings: {
-    //  eslint-import-resolver-node does not seem to play well with monorepo/pattern exports
-    'import-x/resolver': {
-      typescript: true,
+    settings: {
+      //  eslint-import-resolver-node does not seem to play well with monorepo/pattern exports
+      'import-x/resolver': {
+        typescript: true,
+      },
     },
-  },
-});
+  };
+};
 
-export const createJavascriptNodeConfig = (perfectionist = 'relaxed') => [
-  ...commonConfigs(globs.javascript),
-  baseJavascriptConfig(perfectionist),
-  { ignores: ignorePatterns },
-];
+export const createJavascriptNodeConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  return [
+    ...commonConfigs(globs.javascript),
+    baseJavascriptConfig(opts),
+    { ignores: ignorePatterns },
+  ];
+};
 
 const javascriptNode = createJavascriptNodeConfig();
 

--- a/configs/eslint/src/presets/typescript-browser.js
+++ b/configs/eslint/src/presets/typescript-browser.js
@@ -1,12 +1,13 @@
 import globals from 'globals';
 import tsEslint from 'typescript-eslint';
 
-import { globs, typescriptConfigs } from '../common.js';
+import { globs, normalizeOptions, typescriptConfigs } from '../common.js';
 import { createJavascriptNodeConfig } from './javascript-node.js';
 import { baseTypescriptConfig } from './typescript.js';
 
-export const browserTypescriptBrowserConfig = (perfectionist = 'relaxed') => {
-  const base = baseTypescriptConfig(perfectionist);
+export const browserTypescriptBrowserConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  const base = baseTypescriptConfig(opts);
   return {
     ...base,
     languageOptions: {
@@ -22,13 +23,16 @@ export const browserTypescriptBrowserConfig = (perfectionist = 'relaxed') => {
   };
 };
 
-export const createTypescriptBrowserConfig = (perfectionist = 'relaxed') => [
-  ...createJavascriptNodeConfig(perfectionist),
-  ...tsEslint.config(
-    ...typescriptConfigs(globs.typescript),
-    browserTypescriptBrowserConfig(perfectionist),
-  ),
-];
+export const createTypescriptBrowserConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  return [
+    ...createJavascriptNodeConfig(opts),
+    ...tsEslint.config(
+      ...typescriptConfigs(globs.typescript),
+      browserTypescriptBrowserConfig(opts),
+    ),
+  ];
+};
 
 const typescriptBrowserConfig = createTypescriptBrowserConfig();
 

--- a/configs/eslint/src/presets/typescript-isomorphic.js
+++ b/configs/eslint/src/presets/typescript-isomorphic.js
@@ -1,12 +1,13 @@
 import globals from 'globals';
 import tsEslint from 'typescript-eslint';
 
-import { globs, typescriptConfigs } from '../common.js';
+import { globs, normalizeOptions, typescriptConfigs } from '../common.js';
 import { createJavascriptNodeConfig } from './javascript-node.js';
 import { browserTypescriptBrowserConfig } from './typescript-browser.js';
 
-export const isomorphicTypescriptBrowserConfig = (perfectionist = 'relaxed') => {
-  const browserConfig = browserTypescriptBrowserConfig(perfectionist);
+export const isomorphicTypescriptBrowserConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  const browserConfig = browserTypescriptBrowserConfig(opts);
   return {
     ...browserConfig,
     languageOptions: {
@@ -20,13 +21,16 @@ export const isomorphicTypescriptBrowserConfig = (perfectionist = 'relaxed') => 
   };
 };
 
-export const createTypescriptIsomorphicConfig = (perfectionist = 'relaxed') => [
-  ...createJavascriptNodeConfig(perfectionist),
-  ...tsEslint.config(
-    ...typescriptConfigs(globs.typescript),
-    isomorphicTypescriptBrowserConfig(perfectionist),
-  ),
-];
+export const createTypescriptIsomorphicConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  return [
+    ...createJavascriptNodeConfig(opts),
+    ...tsEslint.config(
+      ...typescriptConfigs(globs.typescript),
+      isomorphicTypescriptBrowserConfig(opts),
+    ),
+  ];
+};
 
 const typescriptIsomorphicConfig = createTypescriptIsomorphicConfig();
 

--- a/configs/eslint/src/presets/typescript-next.js
+++ b/configs/eslint/src/presets/typescript-next.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import tsEslint from 'typescript-eslint';
 
-import { globs, typescriptConfigs } from '../common.js';
+import { globs, normalizeOptions, typescriptConfigs } from '../common.js';
 import { getTsConfigFile } from '../utils.js';
 import { createJavascriptNodeConfig } from './javascript-node.js';
 import { browserTypescriptBrowserConfig } from './typescript-browser.js';
@@ -31,11 +31,12 @@ const patchedConfig = fixupConfigRules([...compat.extends('next/core-web-vitals'
   }),
 );
 
-export const createTypescriptNextConfig = (perfectionist = 'relaxed') => {
-  const browserConfig = browserTypescriptBrowserConfig(perfectionist);
+export const createTypescriptNextConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  const browserConfig = browserTypescriptBrowserConfig(opts);
 
   return [
-    ...createJavascriptNodeConfig(perfectionist),
+    ...createJavascriptNodeConfig(opts),
     ...tsEslint.config(
       ...typescriptConfigs(globs.typescript),
       {

--- a/configs/eslint/src/presets/typescript-node.js
+++ b/configs/eslint/src/presets/typescript-node.js
@@ -1,12 +1,13 @@
 import globals from 'globals';
 import tsEslint from 'typescript-eslint';
 
-import { globs, typescriptConfigs } from '../common.js';
+import { globs, normalizeOptions, typescriptConfigs } from '../common.js';
 import { createJavascriptNodeConfig } from './javascript-node.js';
 import { baseTypescriptConfig } from './typescript.js';
 
-export const createTypescriptNodeConfig = (perfectionist = 'relaxed') => {
-  const base = baseTypescriptConfig(perfectionist);
+export const createTypescriptNodeConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  const base = baseTypescriptConfig(opts);
   const nodeTypescriptConfig = {
     ...base,
     languageOptions: {
@@ -20,7 +21,7 @@ export const createTypescriptNodeConfig = (perfectionist = 'relaxed') => {
   };
 
   return [
-    ...createJavascriptNodeConfig(perfectionist),
+    ...createJavascriptNodeConfig(opts),
     ...tsEslint.config(...typescriptConfigs(globs.typescript), nodeTypescriptConfig),
   ];
 };

--- a/configs/eslint/src/presets/typescript-react.js
+++ b/configs/eslint/src/presets/typescript-react.js
@@ -3,13 +3,14 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
 import tsEslint from 'typescript-eslint';
 
-import { globs, typescriptConfigs } from '../common.js';
+import { globs, normalizeOptions, typescriptConfigs } from '../common.js';
 import { createJavascriptNodeConfig } from './javascript-node.js';
 import { browserTypescriptBrowserConfig } from './typescript-browser.js';
 import { baseTypescriptConfig } from './typescript.js';
 
-export const reactTypescriptBrowserConfig = (perfectionist = 'relaxed') => {
-  const base = baseTypescriptConfig(perfectionist);
+export const reactTypescriptBrowserConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  const base = baseTypescriptConfig(opts);
   return {
     ...base,
     languageOptions: {
@@ -23,15 +24,18 @@ export const reactTypescriptBrowserConfig = (perfectionist = 'relaxed') => {
   };
 };
 
-export const createTypescriptReactConfig = (perfectionist = 'relaxed') => [
-  ...createJavascriptNodeConfig(perfectionist),
-  reactHooks.configs['recommended-latest'],
-  reactRefresh.configs.recommended,
-  ...tsEslint.config(
-    ...typescriptConfigs(globs.typescript),
-    browserTypescriptBrowserConfig(perfectionist),
-  ),
-];
+export const createTypescriptReactConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  return [
+    ...createJavascriptNodeConfig(opts),
+    reactHooks.configs['recommended-latest'],
+    reactRefresh.configs.recommended,
+    ...tsEslint.config(
+      ...typescriptConfigs(globs.typescript),
+      browserTypescriptBrowserConfig(opts),
+    ),
+  ];
+};
 
 const typescriptReactConfig = createTypescriptReactConfig();
 

--- a/configs/eslint/src/presets/typescript.js
+++ b/configs/eslint/src/presets/typescript.js
@@ -1,37 +1,50 @@
 import { dirname } from 'node:path';
 import tsEslint from 'typescript-eslint';
 
-import { commonConfigs, commonRules, globs, ignorePatterns, typescriptConfigs } from '../common.js';
+import {
+  commonConfigs,
+  commonRules,
+  globs,
+  ignorePatterns,
+  normalizeOptions,
+  typescriptConfigs,
+} from '../common.js';
 import { getTsConfigFile } from '../utils.js';
 import { baseJavascriptConfig, createJavascriptNodeConfig } from './javascript-node.js';
 
 const project = getTsConfigFile();
 
-export const baseTypescriptConfig = (perfectionist = 'relaxed') => ({
-  ...baseJavascriptConfig(perfectionist),
-  extends: [...commonConfigs(globs.typescript)],
-  files: [globs.typescript],
-  languageOptions: {
-    parserOptions: {
-      project,
-      tsconfigRootDir: dirname(project),
+export const baseTypescriptConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  return {
+    ...baseJavascriptConfig(opts),
+    extends: [...commonConfigs(globs.typescript)],
+    files: [globs.typescript],
+    languageOptions: {
+      parserOptions: {
+        project,
+        tsconfigRootDir: dirname(project),
+      },
     },
-  },
-  name: '@slango.configs/eslint/typescript',
-  rules: {
-    // Allow destructuring (to remove unused properties)
-    '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
-    // Disable as @typescript-eslint/no-unused-vars is used (and no-unused-vars has issues with enums)
-    'no-unused-vars': 'off',
-    ...commonRules(perfectionist),
-  },
-});
+    name: '@slango.configs/eslint/typescript',
+    rules: {
+      // Allow destructuring (to remove unused properties)
+      '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
+      // Disable as @typescript-eslint/no-unused-vars is used (and no-unused-vars has issues with enums)
+      'no-unused-vars': 'off',
+      ...commonRules(opts),
+    },
+  };
+};
 
-export const createTypescriptConfig = (perfectionist = 'relaxed') => [
-  ...createJavascriptNodeConfig(perfectionist),
-  ...tsEslint.config(...typescriptConfigs(globs.typescript), baseTypescriptConfig(perfectionist)),
-  { ignores: ignorePatterns },
-];
+export const createTypescriptConfig = (options = {}) => {
+  const opts = normalizeOptions(options);
+  return [
+    ...createJavascriptNodeConfig(opts),
+    ...tsEslint.config(...typescriptConfigs(globs.typescript), baseTypescriptConfig(opts)),
+    { ignores: ignorePatterns },
+  ];
+};
 
 const typescriptConfig = createTypescriptConfig();
 


### PR DESCRIPTION
## Summary
- allow configuring perfectionist sorting strictness (off/relaxed/strict)
- add preset creators to accept strictness level and document usage

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test Files 6 failed (6))*
- `pnpm build:check`
- `pnpm release:check` *(fails: Failed to find where HEAD diverged from "origin/main". Does "origin/main" exist and it's synced with remote?)*

------
https://chatgpt.com/codex/tasks/task_b_689f6bcef1f88323b002ef6728d3d15d